### PR TITLE
fix: replace netlify:edge identifier with full URL

### DIFF
--- a/netlify/edge-functions/abtest.ts
+++ b/netlify/edge-functions/abtest.ts
@@ -1,4 +1,4 @@
-import type { Context } from "netlify:edge";
+import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
   // look for existing "test_bucket" cookie

--- a/netlify/edge-functions/context-site.ts
+++ b/netlify/edge-functions/context-site.ts
@@ -1,4 +1,4 @@
-import type { Context } from "netlify:edge";
+import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
   return new Response(`Hello from ${context.site.name}!`);

--- a/pages/context-site/README.md
+++ b/pages/context-site/README.md
@@ -9,7 +9,7 @@ Netlify Edge Functions give access to site information via `context.site`.
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import type { Context } from "netlify:edge";
+import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
   return new Response(`Hello from ${context.site.name}!`);

--- a/pages/context-site/index.js
+++ b/pages/context-site/index.js
@@ -8,7 +8,7 @@ export default {
     <section>
       <h1>Access Site Information from Edge Functions</h1>
       <p>Netlify Edge Functions give access to site information via <code>context.site</code>.</p>
-      <pre><code>import type { Context } from "netlify:edge";
+      <pre><code>import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
   return new Response(\`Hello from \${context.site.name}!\`);


### PR DESCRIPTION
### Summary

This replaces `netlify:edge` with `https://edge.netlify.com`.

### Related Github Issues
Part of https://github.com/netlify/pillar-runtime/issues/322.

