### PR TITLE
fix(#30): Updates localized-content with fallback

### DIFF
--- a/netlify/edge-functions/localized-content.js
+++ b/netlify/edge-functions/localized-content.js
@@ -6,10 +6,11 @@ export default async (request, context) => {
     AU: "G'day, mate!",
   };
 
-  const countryCode = context.geo?.country?.code || "UNKNOWN";
+  const countryCode = context.geo?.country?.code;
+  const translation = translations[countryCode] || translations["UNKNOWN"];
   const countryName = context.geo?.country?.name || "somewhere in the world";
 
-  return new Response(`Your personalized greeting for ${countryName} is: ${translations[countryCode]}`, {
+  return new Response(`Your personalized greeting for ${countryName} is: ${translation}`, {
     headers: { "content-type": "text/html" },
   });
 };


### PR DESCRIPTION
## Summary

When a user has a geolocation but their geocode isn't in our list, they would receive an `undefined`. This will make sure instead we use the `UNKNOWN` option as fallback!

This should fix #30.