### PR TITLE
update docs link

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -8,7 +8,7 @@ const explainer = `
   <h2>What are Edge Functions?</h2>
   <p>Using JavaScript and TypeScript, <a href="https://www.netlify.com/products/?utm_campaign=devex&utm_source=edge-functions-examples&utm_medium=web&utm_content=Edge%20Functions%20Product%20Page#netlify-edge-functions" target="_blank" rel="noopener">Netlify Edge Functions</a> give you the power to modify network requests to localize content, serve relevant ads, authenticate visitors, A/B test content, and much more! And this all happens at the <strong>Edge</strong> — directly from the worldwide location closest to each user.</p>
   <p>To use Edge Functions on Netlify, add JavaScript or TypeScript files to an edge-functions directory in your project, and add <code>[[edge_functions]]</code> entries to your netlify.toml file.</p>
-  <p><a href="https://docs.netlify.com/netlify-labs/experimental-features/edge-functions/?utm_campaign=devex&utm_source=edge-functions-examples&utm_medium=web&utm_content=Edge%20Functions%20Docs" target="_blank" rel="noopener">Learn more in the docs</a>.</p>
+  <p><a href="https://docs.netlify.com/edge-functions/overview/?utm_campaign=devex&utm_source=edge-functions-examples&utm_medium=web&utm_content=Edge%20Functions%20Docs" target="_blank" rel="noopener">Learn more in the docs</a>.</p>
 </section>
 `;
 


### PR DESCRIPTION
part of https://github.com/netlify/docs/issues/2310 - updates docs link to point directly to new path for content

I'm not sure how to fix the staging and private CDN deploy previews. I got the same error for the main site deploy preview and retrying the deploy in the netlify UI fixed the issue. However, I don't have perms to do that for the other two sites. 