### PR TITLE
use console.log instead of context.log

### DIFF
--- a/netlify/edge-functions/[page].js
+++ b/netlify/edge-functions/[page].js
@@ -58,7 +58,7 @@ export default async (Request, Context) => {
   const url = new URL(Request.url);
   const path = url.pathname.split("/example/")[1] || "home";
 
-  Context.log(`serve page for ${url} `);
+  console.log(`serve page for ${url} `);
 
   // render the appropriate page with the global layout
   const html = layout({

--- a/netlify/edge-functions/log.ts
+++ b/netlify/edge-functions/log.ts
@@ -1,7 +1,7 @@
 import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
-  context.log("Hello from the logging service");
+  console.log("Hello from the logging service");
 
   return new Response("The request to this URL was logged", {
     headers: { "content-type": "text/html" },

--- a/netlify/edge-functions/set-response-header.ts
+++ b/netlify/edge-functions/set-response-header.ts
@@ -7,7 +7,7 @@ export default async (request: Request, context: Context) => {
     return context.next();
   }
 
-  context.log(`Adding a custom header to the response for ${url}`);
+  console.log(`Adding a custom header to the response for ${url}`);
 
   const response = await context.next();
   response.headers.set("X-Your-Custom-Header", "Your custom header value");

--- a/netlify/edge-functions/transform.ts
+++ b/netlify/edge-functions/transform.ts
@@ -8,7 +8,7 @@ export default async (request: Request, context: Context) => {
     return;
   }
 
-  context.log(`Transforming the response from this ${url}`);
+  console.log(`Transforming the response from this ${url}`);
 
   const response = await context.next();
 

--- a/pages/log/README.md
+++ b/pages/log/README.md
@@ -2,7 +2,7 @@
 
 # Logging with Netlify Edge Functions
 
-Output content to the logs from an Edge Function using `context.log()`.
+Output content to the logs from an Edge Function using `console.log()`.
 
 ## Code example
 
@@ -12,7 +12,7 @@ Edge Functions are files held in the `netlify/edge-functions` directory.
 import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
-  context.log("Hello from the logging service");
+  console.log("Hello from the logging service");
 };
 ```
 

--- a/pages/log/index.js
+++ b/pages/log/index.js
@@ -11,18 +11,13 @@ export default {
       <pre><code>import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
-  context.log("Hello from the logging service");
+  console.log("Hello from the logging service");
 };</code></pre>
       <h2>See this in action</h2>
       <ul>
         <li><a href="/log">Echo content to the logs</a></li>
         <li>${repoLink("log.ts")}</li>
       </ul>
-
-      <div class="protip">
-        <h2>Pro tip!</h2>
-          <p>You can still use <code>console.log()</code> in your Edge Functions, but using <code>context.log()</code> will tell you which Edge Function generated the message for easier debugging!</p>
-      </div>
     </section>
   `;
   },

--- a/pages/transform/README.md
+++ b/pages/transform/README.md
@@ -21,7 +21,7 @@ export default async (request: Request, context: Context) => {
     return;
   }
 
-  context.log(`Transforming the response from this ${url}`);
+  console.log(`Transforming the response from this ${url}`);
 
   const response = await context.next();
 


### PR DESCRIPTION
console.log has been equivalent to context.log for a while now, let's also show that in the examples.
