### PR TITLE
replace context.json with Response.json

### DIFF
--- a/netlify/edge-functions/geolocation.ts
+++ b/netlify/edge-functions/geolocation.ts
@@ -20,7 +20,7 @@ export default async (request: Request, context: Context) => {
   //   }
   // }
 
-  return context.json({
+  return Response.json({
     geo: context.geo,
     header: request.headers.get("x-nf-geo"),
   });

--- a/netlify/edge-functions/json.ts
+++ b/netlify/edge-functions/json.ts
@@ -1,5 +1,5 @@
 import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
-  return context.json({ hello: "world" });
+  return Response.json({ hello: "world" });
 };

--- a/netlify/edge-functions/proxy-requests.ts
+++ b/netlify/edge-functions/proxy-requests.ts
@@ -8,5 +8,5 @@ export default async (request: Request, context: Context) => {
     }
   });
   const jsonData = await joke.json();
-  return context.json(jsonData);
+  return Response.json(jsonData);
 };

--- a/pages/geolocation/index.js
+++ b/pages/geolocation/index.js
@@ -44,7 +44,7 @@ export default async (request: Request, context: Context) => {
   //   }
   // }
 
-  return context.json({
+  return Response.json({
     geo: context.geo,
     header: request.headers.get("x-nf-geo"),
   });

--- a/pages/json/README.md
+++ b/pages/json/README.md
@@ -2,7 +2,7 @@
 
 # JSON Response with Netlify Edge Functions
 
-You can use Edge Functions to return a JSON response by returning `context.json()` with a JavaScript object — no need to
+You can use Edge Functions to return a JSON response by returning `Response.json()` with a JavaScript object — no need to
 `JSON.stringify`!
 
 ## Code example
@@ -13,7 +13,7 @@ Edge Functions are files held in the `netlify/edge-functions` directory.
 import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
-  return context.json({ hello: "world" });
+  return Response.json({ hello: "world" });
 };
 ```
 

--- a/pages/json/index.js
+++ b/pages/json/index.js
@@ -2,18 +2,18 @@ import repoLink from "../../components/repo-link.js";
 
 export default {
   title: "JSON Response",
-  metaDescription: "Use Edge Functions to return a JSON response using Context.json().",
+  metaDescription: "Use Edge Functions to return a JSON response using Response.json().",
   page: function () {
     return `
     <section>
       <h1>JSON Response</h1>
-      <p>You can use Edge Functions to return a JSON response by returning <code>context.json()</code> with a JavaScript object — no need to <code>JSON.stringify</code>!</p>
+      <p>You can use Edge Functions to return a JSON response by returning <code>Response.json()</code> with a JavaScript object — no need to <code>JSON.stringify</code>!</p>
       <p>In this example, we return a JSON object containing <code>hello: "world"</code>.</p>
 
       <pre><code>import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
-  return context.json({ hello: "world" });
+  return Response.json({ hello: "world" });
 };
 </code></pre>
       <h2>See this in action</h2>

--- a/pages/proxy-requests/README.md
+++ b/pages/proxy-requests/README.md
@@ -19,7 +19,7 @@ export default async (request: Request, context: Context) => {
     },
   });
   const jsonData = await joke.json();
-  return context.json(jsonData);
+  return Response.json(jsonData);
 };
 ```
 

--- a/pages/proxy-requests/index.js
+++ b/pages/proxy-requests/index.js
@@ -19,7 +19,7 @@ export default async (request: Request, context: Context) => {
   });
   
   const jsonData = await joke.json();
-  return context.json(jsonData);
+  return Response.json(jsonData);
 };</code></pre>
       <h2>See this in action</h2>
       <ul>
@@ -29,7 +29,7 @@ export default async (request: Request, context: Context) => {
 
       <div class="protip">
         <h2>Pro tip!</h2>
-        <p>Curious about <code>context.json()</code> in the code example above? Check out how you can return a <a href="/example/json">JSON response</a> using Edge Functions.</p>
+        <p>Curious about <code>Response.json()</code> in the code example above? Check out how you can return a <a href="/example/json">JSON response</a> using Edge Functions.</p>
       </div>
     </section>
 `;


### PR DESCRIPTION
We're deprecating `context.json` in favor of `Response.json`. Here's the ef-examples update.