### PR TITLE
Add two long-running stream demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Explore these examples here: https://edge-functions-examples.netlify.app/
 - [Delete cookies](/pages/cookies-delete)
 - [Set up an A/B test using cookies](/pages/abtest)
 
+## Streams
+- [Long-running edge functions](/pages/long-running)
+- [Server-sent events](/pages/server-sent-events)
+
+## WebAssembly
+- [Edge WebAssembly](/pages/wasm)
+
 ## Environment and debugging
 
 - [Write to the logs](/pages/log)

--- a/netlify.toml
+++ b/netlify.toml
@@ -82,6 +82,14 @@
   function = "error"
 
 [[edge_functions]]
+  path = "/long-running"
+  function = "long-running"
+
+[[edge_functions]]
+  path = "/sse"
+  function = "sse"
+
+[[edge_functions]]
   path = "/context-site"
   function = "context-site"
 

--- a/netlify/edge-functions/[page].js
+++ b/netlify/edge-functions/[page].js
@@ -27,6 +27,8 @@ import pageEnvironment from "../../pages/environment/index.js";
 import pageUncaughtExceptions from "../../pages/uncaught-exceptions/index.js";
 import pageContextSite from "../../pages/context-site/index.js";
 import pageWasm from "../../pages/wasm/index.js";
+import pageSse from "../../pages/server-sent-events/index.js";
+import pageLongRunning from "../../pages/long-running/index.js";
 
 // The keys here correspond to the path in the request to `/example/PATH`
 const pages = {
@@ -52,10 +54,12 @@ const pages = {
   "uncaught-exceptions": pageUncaughtExceptions,
   "context-site": pageContextSite,
   "wasm": pageWasm,
+  "server-sent-events": pageSse,
+  "long-running": pageLongRunning,
 };
 
-export default async (Request, Context) => {
-  const url = new URL(Request.url);
+export default (request, context) => {
+  const url = new URL(request.url);
   const path = url.pathname.split("/example/")[1] || "home";
 
   console.log(`serve page for ${url} `);
@@ -64,7 +68,7 @@ export default async (Request, Context) => {
   const html = layout({
     url: url,
     title: pages[path].title,
-    content: pages[path].page({ geo: Context.geo }),
+    content: pages[path].page({ geo: context.geo }),
     metaDescription: pages[path].metaDescription,
   });
 

--- a/netlify/edge-functions/long-running.ts
+++ b/netlify/edge-functions/long-running.ts
@@ -1,0 +1,24 @@
+import type { Context } from "https://edge.netlify.com";
+
+function doSomethingSlow(): Promise<string> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve("You waited a minute for this response");
+    }, 60000);
+  });
+}
+
+export default (request: Request, context: Context) => {
+  const body = new ReadableStream({
+    async start(controller) {
+      const response = await doSomethingSlow();
+      controller.enqueue(new TextEncoder().encode(response));
+      controller.close()
+    }
+  });
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  });
+};

--- a/netlify/edge-functions/sse.ts
+++ b/netlify/edge-functions/sse.ts
@@ -1,0 +1,18 @@
+import type { Context } from "https://edge.netlify.com";
+
+export default async (request: Request, context: Context) => {
+  let index = 0
+  const encoder = new TextEncoder();
+  const body = new ReadableStream({
+    start(controller) {
+      setInterval(() => {
+        controller.enqueue(encoder.encode(`data: Hello ${index++}\n\n`));
+      }, 1000);
+    },
+  });
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+    },
+  });
+};

--- a/pages/home/index.js
+++ b/pages/home/index.js
@@ -2,7 +2,7 @@ export default {
   title: "Home",
   metaDescription: "Explore our library of Edge Function examples and deploy your own to Netlify.",
   page: function () {
-    return `
+    return /* html */`
     <section class="home__section">
     <h2>Examples</h2>
     <p>
@@ -59,6 +59,14 @@ export default {
         <li class="home__sectionListItem"><a class="home__sectionListItemLink" href="/example/cookies-read">Read cookies</a></li>
         <li class="home__sectionListItem"><a class="home__sectionListItemLink" href="/example/cookies-delete">Delete cookies</a></li>
         <li class="home__sectionListItem"><a class="home__sectionListItemLink" href="/example/abtest">Set up an A/B test using cookies</a></li>
+      </ul>
+    </section>
+
+    <section class="home__section">
+      <h3 class="home__sectionHeader">Streams</h3>
+      <ul class="home__sectionList">
+        <li class="home__sectionListItem"><a class="home__sectionListItemLink" href="/example/long-running">Long-running edge functions</a></li>
+        <li class="home__sectionListItem"><a class="home__sectionListItemLink" href="/example/server-sent-events">Server-sent events (SSE)</a></li>
       </ul>
     </section>
 

--- a/pages/long-running/README.md
+++ b/pages/long-running/README.md
@@ -1,0 +1,43 @@
+![Netlify examples](https://user-images.githubusercontent.com/5865/159468750-df1c2783-39b2-40da-9c0f-971f72a7ea3f.png)
+
+# Long-running Netlify Edge Functions
+
+Edge Functions are limited to 50ms of CPU time, but this does not include time spent waiting or making network calls. As long as a function returns headers within 40 seconds it can run indefinitely. If you need to make API calls or perform other work that takes longer than this, you can return a stream from the function and write to it when you have the data.
+
+## Code example
+
+Edge Functions are files held in the `netlify/edge-functions` directory.
+
+```ts
+import type { Context } from "https://edge.netlify.com";
+
+export default (request: Request, context: Context) => {
+  const body = new ReadableStream({
+    async start(controller) {
+      // this might be an API call or other slow external operation
+      const response = await doSomethingSlow();
+      controller.enqueue(new TextEncoder().encode(response));
+      controller.close()
+    }
+  });
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  });
+};
+
+```
+
+- [Explore the code for this Edge Function](../../netlify/edge-functions/sse.ts)
+
+## View this example on the web
+
+- https://edge-functions-examples.netlify.app/example/server-sent-events
+
+## Deploy to Netlify
+
+You can deploy this and all the other examples in this repo as a site of your own to explore and experiment with, by
+clicking this button.
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify/edge-functions-examples&utm_campaign=devex&utm_source=edge-functions-examples&utm_medium=web&utm_content=Deploy%20Edge%20Functions%20Examples%20to%20Netlify)

--- a/pages/long-running/index.js
+++ b/pages/long-running/index.js
@@ -1,0 +1,47 @@
+import repoLink from "../../components/repo-link.js";
+
+export default {
+  title: "Long-running Edge Functions",
+  metaDescription: "Use streams to return data from long-running Edge Functions",
+  page: function () {
+    return /* html */`
+    <section>
+      <h1>Long-running Netlify Edge Functions</h1>
+      <p>Edge Functions are limited to 50ms of CPU time, but this does not include time spent waiting or 
+        making network calls. As long as a function returns headers within 40 seconds it can run indefinitely. 
+        If you need to make API calls or perform other work that takes longer than this, you can return a stream 
+        from the function and write to it when you have the data.
+      </p>
+
+      <pre><code>import type { Context } from "https://edge.netlify.com";
+
+export default (request: Request, context: Context) => {
+  const body = new ReadableStream({
+    async start(controller) {
+      // this might be an API call or other slow external operation
+      const response = await doSomethingSlow();
+      controller.enqueue(new TextEncoder().encode(response));
+      controller.close()
+    }
+  });
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  });
+};
+</code></pre>
+      <h2>See this in action</h2>
+      <ul>
+        <li><a href="/long-running">View the response from the Edge Function (takes 60s to respond)</a></li>
+        <li>${repoLink("long-running.ts")}</li>
+      </ul>
+
+      <div class="protip">
+        <h2>Pro tip!</h2>
+        <p>Need to send updates to the browser from a long-running edge function? Check out the <a href="/example/server-sent-events">server-sent events (SSE)</a> example.</p>
+      </div>
+    </section>
+  `;
+  },
+};

--- a/pages/server-sent-events/README.md
+++ b/pages/server-sent-events/README.md
@@ -1,0 +1,44 @@
+![Netlify examples](https://user-images.githubusercontent.com/5865/159468750-df1c2783-39b2-40da-9c0f-971f72a7ea3f.png)
+
+# Server-Sent Events (SSE) with Netlify Edge Functions
+
+You can use Edge Functions to create a long-running service that can stream data to the browser using [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events). While there is a 50ms limit on CPU time, time spent waiting for a response from an upstream service, or waiting for a timer to expire, does not count towards this limit. This means you can create a long-running service that can stream data to the browser.
+
+## Code example
+
+Edge Functions are files held in the `netlify/edge-functions` directory.
+
+```ts
+import type { Context } from "https://edge.netlify.com";
+
+export default async (request: Request, context: Context) => {
+  let index = 0
+  const encoder = new TextEncoder();
+  const body = new ReadableStream({
+    start(controller) {
+      setInterval(() => {
+        controller.enqueue(encoder.encode(`data: Hello ${index++}\n\n`));
+      }, 1000);
+    },
+  });
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+    },
+  });
+};
+
+```
+
+- [Explore the code for this Edge Function](../../netlify/edge-functions/sse.ts)
+
+## View this example on the web
+
+- https://edge-functions-examples.netlify.app/example/server-sent-events
+
+## Deploy to Netlify
+
+You can deploy this and all the other examples in this repo as a site of your own to explore and experiment with, by
+clicking this button.
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify/edge-functions-examples&utm_campaign=devex&utm_source=edge-functions-examples&utm_medium=web&utm_content=Deploy%20Edge%20Functions%20Examples%20to%20Netlify)

--- a/pages/server-sent-events/index.js
+++ b/pages/server-sent-events/index.js
@@ -1,0 +1,47 @@
+import repoLink from "../../components/repo-link.js";
+
+export default {
+  title: "Server-Sent Events (SSE)",
+  metaDescription: "Use Edge Functions to stream data to the browser using Server-Sent Events",
+  page: function () {
+    return `
+    <section>
+      <h1>Server-Sent Events (SSE)</h1>
+      <p>You can use Edge Functions to create a long-running service that can stream data to the browser using <a href="https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events">Server-Sent Events (SSE)</a>. 
+      While there is a 50ms limit on CPU time, time spent waiting for a response from an upstream service, or waiting for a timer to expire, does not count towards this limit.
+      This means you can create a long-running service that can stream data to the browser.
+      </p>
+
+      <pre><code>import type { Context } from "https://edge.netlify.com";
+
+export default async (request: Request, context: Context) => {
+  let index = 0
+  const encoder = new TextEncoder();
+  const body = new ReadableStream({
+    start(controller) {
+      setInterval(() => {
+        controller.enqueue(encoder.encode(\`data: Hi $\{index++}\\n\\n\`));
+      }, 1000);
+    },
+  });
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+    },
+  });
+};
+</code></pre>
+      <h2>See this in action</h2>
+      <ul>
+        <li><a href="/sse">View the response from the Edge Function</a></li>
+        <li>${repoLink("sse.ts")}</li>
+      </ul>
+
+      <div class="protip">
+        <h2>Pro tip!</h2>
+        <p>Need to wait a long time before starting to stream a response? Check out the <a href="/example/slow-stream">slow streaming</a> example.</p>
+      </div>
+    </section>
+  `;
+  },
+};


### PR DESCRIPTION
Adds two stream demos: one for server-sent events and one for API calls that take over 40s to return