### PR TITLE
Deprecate the https://edge.netlify.com specifier

### DIFF
--- a/netlify/edge-functions/abtest.ts
+++ b/netlify/edge-functions/abtest.ts
@@ -1,4 +1,4 @@
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   // look for existing "test_bucket" cookie

--- a/netlify/edge-functions/context-site.ts
+++ b/netlify/edge-functions/context-site.ts
@@ -1,4 +1,4 @@
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   return new Response(`Hello from ${context.site.name}!`);

--- a/netlify/edge-functions/cookies.ts
+++ b/netlify/edge-functions/cookies.ts
@@ -1,4 +1,4 @@
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   const url = new URL(request.url);

--- a/netlify/edge-functions/country-block.ts
+++ b/netlify/edge-functions/country-block.ts
@@ -1,4 +1,4 @@
-import { Context } from "https://edge.netlify.com";
+import { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   // Here's what's available on context.geo

--- a/netlify/edge-functions/environment.ts
+++ b/netlify/edge-functions/environment.ts
@@ -1,4 +1,4 @@
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   const value = Deno.env.get("MY_IMPORTANT_VARIABLE");

--- a/netlify/edge-functions/geolocation.ts
+++ b/netlify/edge-functions/geolocation.ts
@@ -1,4 +1,4 @@
-import { Context } from "https://edge.netlify.com";
+import { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   // Here's what's available on context.geo

--- a/netlify/edge-functions/image-external.ts
+++ b/netlify/edge-functions/image-external.ts
@@ -1,4 +1,4 @@
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 // Let's serve an image of a kitten from the internet
 

--- a/netlify/edge-functions/image-internal.ts
+++ b/netlify/edge-functions/image-internal.ts
@@ -1,4 +1,4 @@
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 // Let's serve an image that's stored in the repo
 // by rewriting the URL.

--- a/netlify/edge-functions/include.ts
+++ b/netlify/edge-functions/include.ts
@@ -1,4 +1,4 @@
-import { Context } from "https://edge.netlify.com";
+import { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   

--- a/netlify/edge-functions/json.ts
+++ b/netlify/edge-functions/json.ts
@@ -1,4 +1,4 @@
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   return Response.json({ hello: "world" });

--- a/netlify/edge-functions/log.ts
+++ b/netlify/edge-functions/log.ts
@@ -1,4 +1,4 @@
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   console.log("Hello from the logging service");

--- a/netlify/edge-functions/long-running.ts
+++ b/netlify/edge-functions/long-running.ts
@@ -1,4 +1,4 @@
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 function doSomethingSlow(): Promise<string> {
   return new Promise((resolve) => {

--- a/netlify/edge-functions/proxy-requests.ts
+++ b/netlify/edge-functions/proxy-requests.ts
@@ -1,4 +1,4 @@
-import { Context } from "https://edge.netlify.com";
+import { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
 

--- a/netlify/edge-functions/rewrite.ts
+++ b/netlify/edge-functions/rewrite.ts
@@ -1,4 +1,4 @@
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   return new URL("/something-to-serve-with-a-rewrite", request.url);

--- a/netlify/edge-functions/set-request-header.ts
+++ b/netlify/edge-functions/set-request-header.ts
@@ -1,4 +1,4 @@
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   request.headers.set("X-Your-Custom-Header", "Your custom header value");

--- a/netlify/edge-functions/set-response-header.ts
+++ b/netlify/edge-functions/set-response-header.ts
@@ -1,4 +1,4 @@
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   const url = new URL(request.url);

--- a/netlify/edge-functions/sse.ts
+++ b/netlify/edge-functions/sse.ts
@@ -1,4 +1,4 @@
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   let index = 0

--- a/netlify/edge-functions/transform.ts
+++ b/netlify/edge-functions/transform.ts
@@ -1,4 +1,4 @@
-import { Context } from "https://edge.netlify.com";
+import { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   const url = new URL(request.url);

--- a/pages/abtest/index.js
+++ b/pages/abtest/index.js
@@ -11,7 +11,7 @@ export default {
       <p>Visitors can then be redirected to different pages, depending on the bucket and cookie they were assigned.</p> 
       <p>You could even use A/B testing in combination with Geolocation at The Edge!</p>
 
-      <pre><code>import type { Context } from "https://edge.netlify.com";
+      <pre><code>import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   // look for existing "test_bucket" cookie

--- a/pages/context-site/README.md
+++ b/pages/context-site/README.md
@@ -9,7 +9,7 @@ Netlify Edge Functions give access to site information via `context.site`.
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   return new Response(`Hello from ${context.site.name}!`);

--- a/pages/context-site/index.js
+++ b/pages/context-site/index.js
@@ -8,7 +8,7 @@ export default {
     <section>
       <h1>Access Site Information from Edge Functions</h1>
       <p>Netlify Edge Functions give access to site information via <code>context.site</code>.</p>
-      <pre><code>import type { Context } from "https://edge.netlify.com";
+      <pre><code>import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   return new Response(\`Hello from \${context.site.name}!\`);

--- a/pages/cookies-delete/README.md
+++ b/pages/cookies-delete/README.md
@@ -9,7 +9,7 @@ Manipulate HTTP cookies
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   // Set a cookie

--- a/pages/cookies-delete/index.js
+++ b/pages/cookies-delete/index.js
@@ -8,7 +8,7 @@ export default {
     <section>
       <h1>Delete HTTP cookies</h1>
       <p>Use an Edge Function to delete cookies.</p>
-      <pre><code>import type { Context } from "https://edge.netlify.com";
+      <pre><code>import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   // Delete a cookie

--- a/pages/cookies-read/README.md
+++ b/pages/cookies-read/README.md
@@ -9,7 +9,7 @@ Manipulate HTTP cookies
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   // Set a cookie

--- a/pages/cookies-read/index.js
+++ b/pages/cookies-read/index.js
@@ -8,7 +8,7 @@ export default {
     <section>
       <h1>Reading cookies</h1>
       <p>Use an Edge Function to read and manage HTTP cookies.</p>
-      <pre><code>import type { Context } from "https://edge.netlify.com";
+      <pre><code>import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {  
   // Read the value of a cookie

--- a/pages/cookies-set/README.md
+++ b/pages/cookies-set/README.md
@@ -9,7 +9,7 @@ Manipulate HTTP cookies
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   // Set a cookie

--- a/pages/cookies-set/index.js
+++ b/pages/cookies-set/index.js
@@ -8,7 +8,7 @@ export default {
     <section>
       <h1>Setting cookies</h1>
       <p>Use an Edge Function to create and manage HTTP cookies.</p>
-      <pre><code>import type { Context } from "https://edge.netlify.com";
+      <pre><code>import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {  
   // Set a cookie    

--- a/pages/country-block/index.js
+++ b/pages/country-block/index.js
@@ -10,7 +10,7 @@ export default {
       <p>You can use geolocation data to identify a user's country and block content if required.</p>
       <p>Geolocation information is available on the <code>Context.geo</code> object.</p>
 
-      <pre><code>import { Context } from "https://edge.netlify.com";
+      <pre><code>import { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   const BLOCKED_COUNTRY_CODE = "GB";

--- a/pages/environment/README.md
+++ b/pages/environment/README.md
@@ -10,7 +10,7 @@ use the `Deno.env` API.
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   const value = Deno.env.get("MY_IMPORTANT_VARIABLE");

--- a/pages/environment/index.js
+++ b/pages/environment/index.js
@@ -9,7 +9,7 @@ export default {
       <h1>Use environment variables</h1>
       <p>Netlify Edge Functions support open-source Deno APIs. To access your Netlify environment variables in Edge Functions, use the <code>Deno.env</code> API.</p> 
 
-      <pre><code>import type { Context } from "https://edge.netlify.com";
+      <pre><code>import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   const value = Deno.env.get("MY_IMPORTANT_VARIABLE");

--- a/pages/geolocation/index.js
+++ b/pages/geolocation/index.js
@@ -22,7 +22,7 @@ export default {
       
       <p>Geolocation information is available on the <code>Context.geo</code> object.</p>
 
-      <pre><code>import { Context } from "https://edge.netlify.com";
+      <pre><code>import { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   // Here's what's available on context.geo

--- a/pages/image/index.js
+++ b/pages/image/index.js
@@ -9,7 +9,7 @@ export default {
       <h1>Image Response</h1>
       <p>You can use Edge Functions to return an image.</p>
 
-      <pre><code>import type { Context } from "https://edge.netlify.com";
+      <pre><code>import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
 

--- a/pages/include/README.md
+++ b/pages/include/README.md
@@ -13,7 +13,7 @@ some other content.
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import { Context } from "https://edge.netlify.com";
+import { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   // Get the page content

--- a/pages/include/index.js
+++ b/pages/include/index.js
@@ -14,7 +14,7 @@ export default {
       In this example, we look for an <code>{{INCLUDE_PRICE_INFO}}</code> placeholder in our response, and replace it with some other content.
     </p>
 
-    <pre><code>import { Context } from "https://edge.netlify.com";
+    <pre><code>import { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   

--- a/pages/json/README.md
+++ b/pages/json/README.md
@@ -10,7 +10,7 @@ You can use Edge Functions to return a JSON response by returning `Response.json
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   return Response.json({ hello: "world" });

--- a/pages/json/index.js
+++ b/pages/json/index.js
@@ -10,7 +10,7 @@ export default {
       <p>You can use Edge Functions to return a JSON response by returning <code>Response.json()</code> with a JavaScript object — no need to <code>JSON.stringify</code>!</p>
       <p>In this example, we return a JSON object containing <code>hello: "world"</code>.</p>
 
-      <pre><code>import type { Context } from "https://edge.netlify.com";
+      <pre><code>import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   return Response.json({ hello: "world" });

--- a/pages/log/README.md
+++ b/pages/log/README.md
@@ -9,7 +9,7 @@ Output content to the logs from an Edge Function using `console.log()`.
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   console.log("Hello from the logging service");

--- a/pages/log/index.js
+++ b/pages/log/index.js
@@ -8,7 +8,7 @@ export default {
     <section>
       <h1>Logging with Edge Functions</h1>
       <p>You can output content to the logs during the execution of your Edge Function.</p>
-      <pre><code>import type { Context } from "https://edge.netlify.com";
+      <pre><code>import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   console.log("Hello from the logging service");

--- a/pages/long-running/README.md
+++ b/pages/long-running/README.md
@@ -9,7 +9,7 @@ Edge Functions are limited to 50ms of CPU time, but this does not include time s
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default (request: Request, context: Context) => {
   const body = new ReadableStream({

--- a/pages/long-running/index.js
+++ b/pages/long-running/index.js
@@ -13,7 +13,7 @@ export default {
         from the function and write to it when you have the data.
       </p>
 
-      <pre><code>import type { Context } from "https://edge.netlify.com";
+      <pre><code>import type { Context } from "@netlify/edge-functions";
 
 export default (request: Request, context: Context) => {
   const body = new ReadableStream({

--- a/pages/proxy-requests/README.md
+++ b/pages/proxy-requests/README.md
@@ -10,7 +10,7 @@ Edge Function.
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import { Context } from "https://edge.netlify.com";
+import { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   const joke = await fetch("https://icanhazdadjoke.com/", {

--- a/pages/proxy-requests/index.js
+++ b/pages/proxy-requests/index.js
@@ -8,7 +8,7 @@ export default {
     <section>
       <h1>Proxy requests to another source</h1>
       <p>You can use <a href="https://developer.mozilla.org/en-US/docs/Web/API/fetch" target="_BLANK" rel=noopener>fetch()</a> to make requests to other sources via an Edge Function.</p>
-      <pre><code>import { Context } from "https://edge.netlify.com";
+      <pre><code>import { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
 

--- a/pages/rewrite/README.md
+++ b/pages/rewrite/README.md
@@ -9,7 +9,7 @@ You can rewrite requests on one URL to resources available on another URL using 
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   return new URL("/something-to-serve-with-a-rewrite", request.url);

--- a/pages/rewrite/index.js
+++ b/pages/rewrite/index.js
@@ -8,7 +8,7 @@ export default {
     <section>
       <h1>Rewrite with Edge Functions</h1>
       <p>You can rewrite requests on one URL to resources available on another URL using an Edge Function.</p>
-      <pre><code>import type { Context } from "https://edge.netlify.com";
+      <pre><code>import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   return new URL("/something-to-serve-with-a-rewrite", request.url);

--- a/pages/server-sent-events/README.md
+++ b/pages/server-sent-events/README.md
@@ -9,7 +9,7 @@ You can use Edge Functions to create a long-running service that can stream data
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   let index = 0

--- a/pages/server-sent-events/index.js
+++ b/pages/server-sent-events/index.js
@@ -12,7 +12,7 @@ export default {
       This means you can create a long-running service that can stream data to the browser.
       </p>
 
-      <pre><code>import type { Context } from "https://edge.netlify.com";
+      <pre><code>import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   let index = 0

--- a/pages/set-request-header/README.md
+++ b/pages/set-request-header/README.md
@@ -9,7 +9,7 @@ Use an Edge Function to add HTTP headers to any HTTP request at The Edge.
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   const response = await context.next();

--- a/pages/set-request-header/index.js
+++ b/pages/set-request-header/index.js
@@ -8,7 +8,7 @@ export default {
     <section>
       <h1>Set custom HTTP request headers with an Edge Function</h1>
       <p>Use an Edge Function to add HTTP headers to any HTTP request.</p>
-      <pre><code>import type { Context } from "https://edge.netlify.com";
+      <pre><code>import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   request.headers.set("X-Your-Custom-Header", "Your custom header value");

--- a/pages/set-response-header/README.md
+++ b/pages/set-response-header/README.md
@@ -9,7 +9,7 @@ Use an Edge Function to add HTTP headers to any HTTP response at The Edge.
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import type { Context } from "https://edge.netlify.com";
+import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   const response = await context.next();

--- a/pages/set-response-header/index.js
+++ b/pages/set-response-header/index.js
@@ -8,7 +8,7 @@ export default {
     <section>
       <h1>Set custom HTTP response headers with an Edge Function</h1>
       <p>Use an Edge Function to add HTTP headers to any HTTP response.</p>
-      <pre><code>import type { Context } from "https://edge.netlify.com";
+      <pre><code>import type { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   const response = await context.next();

--- a/pages/transform/README.md
+++ b/pages/transform/README.md
@@ -11,7 +11,7 @@ request to `/hello` with JavaScript's <code>toUpperCase()</code> function, using
 Edge Functions are files held in the `netlify/edge-functions` directory.
 
 ```ts
-import { Context } from "https://edge.netlify.com";
+import { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   const url = new URL(request.url);

--- a/pages/transform/index.js
+++ b/pages/transform/index.js
@@ -11,7 +11,7 @@ export default {
         You can use Edge Functions to transform the content of an HTTP response. In this example, we transform the response of a request to <a href="/hello">/hello</a> with a <code>toUpperCase()</code> function, using the query parameter <code>method=transform</code>.
       </p>
 
-      <pre><code>import { Context } from "https://edge.netlify.com";
+      <pre><code>import { Context } from "@netlify/edge-functions";
 
 export default async (request: Request, context: Context) => {
   const url = new URL(request.url);


### PR DESCRIPTION
https://github.com/netlify/pod-dev-foundations/issues/582

We've introduced an improved type specifier, `@netlify/edge-functions`, so the examples need to be updated