### PR TITLE
Use Netlify.env instead of Deno.env

### DIFF
--- a/netlify/edge-functions/environment.ts
+++ b/netlify/edge-functions/environment.ts
@@ -1,7 +1,7 @@
 import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
-  const value = Deno.env.get("MY_IMPORTANT_VARIABLE");
+  const value = Netlify.env.get("MY_IMPORTANT_VARIABLE");
 
   return new Response(`Value of MY_IMPORTANT_VARIABLE is "${value}".`, {
     headers: { "content-type": "text/html" },

--- a/pages/environment/README.md
+++ b/pages/environment/README.md
@@ -3,7 +3,7 @@
 # Use environment variables with Netlify Edge Functions
 
 Netlify Edge Functions support open-source Deno APIs. To access your Netlify environment variables in Edge Functions,
-use the `Deno.env` API.
+use the `Netlify.env` API.
 
 ## Code example
 
@@ -13,7 +13,7 @@ Edge Functions are files held in the `netlify/edge-functions` directory.
 import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
-  const value = Deno.env.get("MY_IMPORTANT_VARIABLE");
+  const value = Netlify.env.get("MY_IMPORTANT_VARIABLE");
 
   return new Response(&grave;Value of MY_IMPORTANT_VARIABLE is "&dollar;{value}".&grave;, {
     headers: { "content-type": "text/html" },

--- a/pages/environment/index.js
+++ b/pages/environment/index.js
@@ -7,12 +7,12 @@ export default {
     return `
     <section>
       <h1>Use environment variables</h1>
-      <p>Netlify Edge Functions support open-source Deno APIs. To access your Netlify environment variables in Edge Functions, use the <code>Deno.env</code> API.</p> 
+      <p>To access your Netlify environment variables in Edge Functions, use the <code>Netlify.env</code> API.</p>
 
       <pre><code>import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
-  const value = Deno.env.get("MY_IMPORTANT_VARIABLE");
+  const value = Netlify.env.get("MY_IMPORTANT_VARIABLE");
 
   return new Response(&grave;Value of MY_IMPORTANT_VARIABLE is "&dollar;{value}".&grave;, {
     headers: { "content-type": "text/html" },
@@ -21,7 +21,7 @@ export default async (request: Request, context: Context) => {
       <h2>See this in action</h2>
       <ul>
         <li><a href="/environment">View the response from the Edge Function</a></li>
-        <li><a href="https://doc.deno.land/deno/stable/~/Deno.env" target="_blank" rel="noopener">View the Deno.env API docs</a></li>
+        <li><a href="https://docs.netlify.com/edge-functions/api/#netlify-global-object" target="_blank" rel="noopener">View the Netlify.env API docs</a></li>
         <li>${repoLink("environment.ts")}</li>
       </ul>
     </section>


### PR DESCRIPTION
Netlify.env is a new API that allows for more customization of the Edge Functions runtime, so we'd like to use that instead of the Deno.env